### PR TITLE
Add benchmarks with DMap

### DIFF
--- a/benchmark/CacheMap.hs
+++ b/benchmark/CacheMap.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ExplicitNamespaces   #-}
 {-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -25,7 +24,7 @@ import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
 import GHC.TypeLits
 
-import Data.TypeRep.Map (TF (..), TypeRepMap (..), fromList, lookup)
+import Data.TypeRep.CacheMap (TF (..), TypeRepMap (..), fromList, lookup)
 
 benchCacheMap :: Benchmark
 benchCacheMap = bgroup "vector optimal cache"

--- a/benchmark/DMap.hs
+++ b/benchmark/DMap.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE ExplicitNamespaces   #-}
+{-# LANGUAGE InstanceSigs         #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver -fno-warn-orphans #-}
+
+module DMap
+       ( benchDMap
+       , prepareBenchDMap
+       ) where
+
+import Criterion.Main (Benchmark, bench, bgroup, nf)
+
+import Prelude hiding (lookup)
+
+import Control.DeepSeq (rnf)
+import Control.Exception
+import Data.Functor.Identity (Identity (..))
+import Data.Maybe (fromJust)
+import Data.Proxy (Proxy (..))
+import Data.Type.Equality ((:~:) (..))
+import GHC.TypeLits
+import Type.Reflection (TypeRep, Typeable, typeRep)
+import Type.Reflection.Unsafe (typeRepFingerprint)
+import Unsafe.Coerce (unsafeCoerce)
+
+import Data.Dependent.Map (DMap, empty, insert, keys, lookup)
+import Data.GADT.Compare (GCompare (..), GEq (..), GOrdering (..))
+import Data.Some (Some (This))
+
+benchDMap :: Benchmark
+benchDMap = bgroup "dependent map"
+   [ bench "lookup"     $ nf tenLookups bigMap
+   -- , bench "insert new" $ whnf (\x -> rknf $ insert x bigMap) (Proxy :: Proxy 9999999999)
+   -- , bench "update old" $ whnf (\x -> rknf $ insert x bigMap) (Proxy :: Proxy 1)
+   ]
+
+tenLookups :: DMap TypeRep Identity
+           -> ( Proxy 10, Proxy 20, Proxy 30, Proxy 40
+              , Proxy 50, Proxy 60, Proxy 70, Proxy 80
+              )
+tenLookups tmap = (lp, lp, lp, lp, lp, lp, lp, lp)
+  where
+    lp :: forall (a :: Nat) . Typeable a => Proxy a
+    lp = runIdentity $ fromJust $ lookup (typeRep @(Proxy a)) tmap
+
+-- TypeRepMap of 10000 elements
+bigMap :: DMap TypeRep Identity
+bigMap = buildBigMap 10000 (Proxy :: Proxy 0) empty
+
+buildBigMap :: forall a . (KnownNat a)
+            => Int
+            -> Proxy (a :: Nat)
+            -> DMap TypeRep Identity
+            -> DMap TypeRep Identity
+buildBigMap 1 x = insert (typeRep @(Proxy a)) $ Identity x
+buildBigMap n x = insert (typeRep @(Proxy a)) (Identity x)
+                . buildBigMap (n - 1) (Proxy @(a + 1))
+
+rknf :: DMap TypeRep f -> ()
+rknf = rnf . map (\(This t) -> typeRepFingerprint t) . keys
+
+prepareBenchDMap :: IO ()
+prepareBenchDMap = evaluate (rknf bigMap)
+
+instance GEq TypeRep where
+    geq :: TypeRep a -> TypeRep b -> Maybe (a :~: b)
+    geq (typeRepFingerprint -> a) (typeRepFingerprint -> b) =
+        if a == b
+            then Just $ unsafeCoerce Refl
+            else Nothing
+
+instance GCompare TypeRep where
+    gcompare :: TypeRep a -> TypeRep b -> GOrdering a b
+    gcompare (typeRepFingerprint -> a) (typeRepFingerprint -> b) =
+        case compare a b of
+            EQ -> unsafeCoerce GEQ
+            LT -> GLT
+            GT -> GGT

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -4,6 +4,7 @@ import Criterion.Main (defaultMain)
 
 import CacheMap (benchCacheMap, prepareBenchCacheMap)
 import CMap (benchMap, prepareBenchMap)
+import DMap (benchDMap, prepareBenchDMap)
 import OptimalVector (benchVectorOpt, prepareBenchVectorOpt)
 --import Vector (benchVector, prepareBenchVector)
 
@@ -13,9 +14,11 @@ main = do
   prepareBenchCacheMap
   --prepareBenchVector
   prepareBenchVectorOpt
+  prepareBenchDMap
   defaultMain
     [ benchMap
    -- , benchVector
     , benchCacheMap
     , benchVectorOpt
+    , benchDMap
     ]

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE CPP #-}
+
 module Main where
 
 import Criterion.Main (defaultMain)
 
 import CacheMap (benchCacheMap, prepareBenchCacheMap)
 import CMap (benchMap, prepareBenchMap)
+#if ( __GLASGOW_HASKELL__ >= 802 )
 import DMap (benchDMap, prepareBenchDMap)
+#endif
 import OptimalVector (benchVectorOpt, prepareBenchVectorOpt)
 --import Vector (benchVector, prepareBenchVector)
 
@@ -14,11 +18,15 @@ main = do
   prepareBenchCacheMap
   --prepareBenchVector
   prepareBenchVectorOpt
+#if ( __GLASGOW_HASKELL__ >= 802 )
   prepareBenchDMap
+#endif
   defaultMain
     [ benchMap
    -- , benchVector
     , benchCacheMap
     , benchVectorOpt
+#if ( __GLASGOW_HASKELL__ >= 802 )
     , benchDMap
+#endif
     ]

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -72,13 +72,15 @@ benchmark typerep-map-benchmark
   main-is:             Main.hs
   other-modules:       CMap
                      , CacheMap
+                     , DMap
                      , Vector
                      , OptimalVector
   build-depends:       base
                      , criterion
-                     , typerep-map
                      , typerep-map-internal
                      , deepseq
+                     , dependent-map
+                     , dependent-sum
                      , ghc-typelits-knownnat
   default-extensions:  OverloadedStrings
                        RecordWildCards

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -72,7 +72,6 @@ benchmark typerep-map-benchmark
   main-is:             Main.hs
   other-modules:       CMap
                      , CacheMap
-                     , DMap
                      , Vector
                      , OptimalVector
   build-depends:       base
@@ -86,7 +85,8 @@ benchmark typerep-map-benchmark
                        RecordWildCards
                        ScopedTypeVariables
                        TypeApplications
-
+  if impl(ghc >= 8.2.2)
+    other-modules:     DMap
 
 source-repository head
   type:                git


### PR DESCRIPTION
Resolves #12 

Here are the results with `dependent-map` library `DMap`:

```
benchmarking map/lookup
time                 2.292 μs   (2.286 μs .. 2.298 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.290 μs   (2.287 μs .. 2.295 μs)
std dev              13.30 ns   (9.966 ns .. 17.37 ns)

benchmarking vector optimal cache/lookup
time                 263.7 ns   (263.1 ns .. 264.7 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 263.8 ns   (263.2 ns .. 264.7 ns)
std dev              2.142 ns   (1.728 ns .. 2.970 ns)

benchmarking dependent map/lookup
time                 886.1 ns   (885.0 ns .. 887.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 887.3 ns   (885.9 ns .. 890.2 ns)
std dev              5.727 ns   (3.374 ns .. 9.931 ns)
```

