### PR TITLE
[#21] Unpack fields

### DIFF
--- a/internal/Data/TypeRep/CacheMap.hs
+++ b/internal/Data/TypeRep/CacheMap.hs
@@ -48,9 +48,9 @@ import qualified Data.Vector.Unboxed as Unboxed
 
 -- | Map-like data structure that keeps types as keys.
 data TypeRepMap (f :: k -> Type) = TypeRepMap
-    { fingerprintAs :: Unboxed.Vector Word64
-    , fingerprintBs :: Unboxed.Vector Word64
-    , anys          :: V.Vector Any
+    { fingerprintAs :: {-# UNPACK #-} !(Unboxed.Vector Word64)
+    , fingerprintBs :: {-# UNPACK #-} !(Unboxed.Vector Word64)
+    , anys          :: {-# UNPACK #-} !(V.Vector Any)
     }
 
 -- | Shows only 'Fingerprint's.


### PR DESCRIPTION
Resolves #21 
Results before:
```
benchmarking vector optimal cache/lookup
time                 250.5 ns   (250.0 ns .. 251.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 250.4 ns   (249.9 ns .. 250.8 ns)
std dev              1.476 ns   (1.249 ns .. 1.873 ns)
```
Results after:
```
benchmarking vector optimal cache/lookup
time                 236.3 ns   (235.9 ns .. 236.5 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 236.1 ns   (235.7 ns .. 236.7 ns)
std dev              1.523 ns   (1.158 ns .. 2.143 ns)
```