### PR TITLE
[#20] Use PrimArray instead of Vector

### DIFF
--- a/benchmark/CacheMap.hs
+++ b/benchmark/CacheMap.hs
@@ -10,15 +10,12 @@
 
 module CacheMap
        ( benchCacheMap
-       , prepareBenchCacheMap
        ) where
 
 import Criterion.Main (Benchmark, bench, bgroup, nf)
 
 import Prelude hiding (lookup)
 
-import Control.DeepSeq (rnf)
-import Control.Exception
 import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
@@ -53,9 +50,3 @@ buildBigMap :: forall a . (KnownNat a)
             -> [TF (Proxy :: Nat -> *)]
 buildBigMap 1 x = (TF x :)
 buildBigMap n x = (TF x :) . buildBigMap (n - 1) (Proxy :: Proxy (a + 1))
-
-rknf :: TypeRepMap f -> ()
-rknf tVect = rnf (fingerprintAs tVect, fingerprintBs tVect)
-
-prepareBenchCacheMap :: IO ()
-prepareBenchCacheMap = evaluate (rknf bigMap)

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Criterion.Main (defaultMain)
 
-import CacheMap (benchCacheMap, prepareBenchCacheMap)
+import CacheMap (benchCacheMap)
 import CMap (benchMap, prepareBenchMap)
 #if ( __GLASGOW_HASKELL__ >= 802 )
 import DMap (benchDMap, prepareBenchDMap)
@@ -15,7 +15,6 @@ import OptimalVector (benchVectorOpt, prepareBenchVectorOpt)
 main :: IO ()
 main = do
   prepareBenchMap
-  prepareBenchCacheMap
   --prepareBenchVector
   prepareBenchVectorOpt
 #if ( __GLASGOW_HASKELL__ >= 802 )

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
 resolver: nightly-2018-07-05
+
+extra-deps:
+  - primitive-0.6.4.0

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -43,6 +43,7 @@ library typerep-map-internal
   build-depends:       base
                      , containers
                      , ghc-prim
+                     , primitive
                      , vector
   default-extensions:  OverloadedStrings
                        RecordWildCards


### PR DESCRIPTION
Even better results:
```
benchmarking vector optimal cache/lookup
time                 200.4 ns   (199.7 ns .. 201.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 199.4 ns   (198.9 ns .. 200.2 ns)
std dev              2.059 ns   (1.787 ns .. 2.375 ns)
```

Resolves #20