### PR TITLE
[#47] Add Eq instance to TypeRepMap using QuantifiedConstraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 git:
   depth: 5
 
-cabal: "2.0"
+cabal: "2.4"
 
 cache:
   directories:
@@ -18,7 +18,7 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.3
 
-  - ghc: 8.6.3
+  - ghc: 8.6.4
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:
@@ -35,7 +35,7 @@ install:
 script:
   - |
     if [ -z "$STACK_YAML" ]; then
-      cabal new-test $ALLOWNEWER
+      cabal new-test --enable-tests
     else
       stack build --system-ghc --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
-Change log
-==========
+# Changelog
 
 `typerep-map` uses [PVP Versioning][1].
-The change log is available [on GitHub][2].
+The changelog is available [on GitHub][2].
 
-# 0.3.1
+## 0.3.2 — Mar 27, 2019
+
+* [#47](https://github.com/kowainik/typerep-map/issues/47):
+  Add `Eq` instance for `TypeRepMap` using `-XQuantifiedConstraints`.
+* [#70](https://github.com/kowainik/typerep-map/issues/70):
+  Bump up to `dependent-sum-0.5`.
+
+## 0.3.1
 
 * [#64](https://github.com/kowainik/typerep-map/issues/64):
   Fix segfault in `toList`.
 * Support GHC 8.4.4 and 8.6.3.
 
-# 0.3.0
+## 0.3.0
 
 * [#46](https://github.com/kowainik/typerep-map/issues/46):
   Make `Show` instance for `TypeRepMap` show keys.
@@ -22,7 +28,7 @@ The change log is available [on GitHub][2].
   instead of `IntMap`.
 
 
-# 0.2.0
+## 0.2.0
 
 * [#43](https://github.com/kowainik/typerep-map/issues/43):
   Implement `IsList` instance for `TypeRepMap`.
@@ -32,7 +38,7 @@ The change log is available [on GitHub][2].
   Add `map` function for `TMap`.
 * Drop support for `ghc-8.0.2`.
 
-# 0.1.0
+## 0.1.0
 
 * Initially created.
 

--- a/test/Test/TypeRep/MapProperty.hs
+++ b/test/Test/TypeRep/MapProperty.hs
@@ -65,28 +65,17 @@ test_DeleteMember = prop "member k . delete k == False" $ do
 -- Semigroup and Monoid laws
 ----------------------------------------------------------------------------
 
--- This newtype is used to compare 'TypeRepMap's using only 'Fingerprint's. It's
--- not a good idea to write such `Eq` instance for `TypeRepMap` itself because
--- it doesn't compare values so it's not true equality. But this should be
--- enough for tests.
-newtype FpMap f = FpMap (TypeRepMap f)
-  deriving (Show, Semigroup, Monoid)
-
-instance Eq (FpMap f) where
-    FpMap (TypeRepMap as1 bs1 _ _) == FpMap (TypeRepMap as2 bs2 _ _) =
-        as1 == as2 && bs1 == bs2
-
 test_SemigroupAssoc :: PropertyTest
 test_SemigroupAssoc = prop "x <> (y <> z) == (x <> y) <> z" $ do
-    x <- FpMap <$> forAll genMap
-    y <- FpMap <$> forAll genMap
-    z <- FpMap <$> forAll genMap
+    x <- forAll genMap
+    y <- forAll genMap
+    z <- forAll genMap
 
     (x <> (y <> z)) === ((x <> y) <> z)
 
 test_MonoidIdentity :: PropertyTest
 test_MonoidIdentity = prop "x <> mempty == mempty <> x == x" $ do
-    x <- FpMap <$> forAll genMap
+    x <- forAll genMap
 
     x <> mempty === x
     mempty <> x === x

--- a/test/Test/TypeRep/MapProperty.hs
+++ b/test/Test/TypeRep/MapProperty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
@@ -65,17 +66,40 @@ test_DeleteMember = prop "member k . delete k == False" $ do
 -- Semigroup and Monoid laws
 ----------------------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ < 806
+-- This newtype is used to compare 'TypeRepMap's using only 'Fingerprint's. It's
+-- not a good idea to write such `Eq` instance for `TypeRepMap` itself because
+-- it doesn't compare values so it's not true equality. But this should be
+-- enough for tests.
+newtype FpMap f = FpMap (TypeRepMap f)
+  deriving (Show, Semigroup, Monoid)
+
+instance Eq (FpMap f) where
+    FpMap (TypeRepMap as1 bs1 _ _) == FpMap (TypeRepMap as2 bs2 _ _) =
+        as1 == as2 && bs1 == bs2
+#endif
+
 test_SemigroupAssoc :: PropertyTest
 test_SemigroupAssoc = prop "x <> (y <> z) == (x <> y) <> z" $ do
+#if __GLASGOW_HASKELL__ >= 806
     x <- forAll genMap
     y <- forAll genMap
     z <- forAll genMap
+#else
+    x <- FpMap <$> forAll genMap
+    y <- FpMap <$> forAll genMap
+    z <- FpMap <$> forAll genMap
+#endif
 
     (x <> (y <> z)) === ((x <> y) <> z)
 
 test_MonoidIdentity :: PropertyTest
 test_MonoidIdentity = prop "x <> mempty == mempty <> x == x" $ do
+#if __GLASGOW_HASKELL__ >= 806
     x <- forAll genMap
+#else
+    x <- FpMap <$> forAll genMap
+#endif
 
     x <> mempty === x
     mempty <> x === x

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -1,5 +1,5 @@
 name:                typerep-map
-version:             0.3.1
+version:             0.3.2
 synopsis:            Efficient implementation of a dependent map with types as keys
 description:
     A dependent map from type representations to values of these types.


### PR DESCRIPTION
Resolves #47 

I've tested in REPL and it seems working:

```haskell
λ: import Data.TypeRepMap as T
λ: tm1 = T.one (Proxy @3)
λ: tm2 = T.one (Proxy @3) <> T.one (Proxy @4)
λ: tm1 == tm2
False
λ: tm1 == tm1
True
λ: tm2 == tm2
True
```

Also, due to this instance it became possible to simplify existing tests.