### PR TITLE
[#73] Bump up to GHC 8.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
   include:
   - ghc: 8.2.2
   - ghc: 8.4.4
-  - ghc: 8.6.3
+  - ghc: 8.6.5
 
-  - ghc: 8.6.4
+  - ghc: 8.6.5
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # typerep-map
 
 ![electricity](https://user-images.githubusercontent.com/8126674/44323413-788dd700-a484-11e8-842e-f224cfaa4206.png)
-[![Hackage](https://img.shields.io/hackage/v/typerep-map.svg)](https://hackage.haskell.org/package/typerep-map)
-[![Build status](https://secure.travis-ci.org/kowainik/typerep-map.svg)](https://travis-ci.org/kowainik/typerep-map)
+[![Build status](https://img.shields.io/travis/kowainik/typerep-map.svg?logo=travis)](https://travis-ci.org/kowainik/typerep-map)
+[![Hackage](https://img.shields.io/hackage/v/typerep-map.svg?logo=haskell)](https://hackage.haskell.org/package/typerep-map)
+[![Stackage LTS](http://stackage.org/package/typerep-map/badge/lts)](http://stackage.org/lts/package/typerep-map)
+[![Stackage Nightly](http://stackage.org/package/typerep-map/badge/nightly)](http://stackage.org/nightly/package/typerep-map)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/vrom911/typerep-map/blob/master/LICENSE)
 
 `typerep-map` introduces `TMap` and `TypeRepMap` — data structures like [`Map`](http://hackage.haskell.org/package/containers-0.6.0.1/docs/Data-Map-Lazy.html#t:Map), but where types serve as keys, and values have the types specified in the corresponding key spots.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
-resolver: lts-13.14
+resolver: lts-13.21
 
 extra-deps:
   - dependent-sum-0.5
-  - tasty-hedgehog-0.2.0.0
+  - hedgehog-1.0
+  - tasty-hedgehog-1.0.0.0

--- a/test/Test/TypeRep/CMap.hs
+++ b/test/Test/TypeRep/CMap.hs
@@ -35,7 +35,7 @@ mapOf10 = insert (Identity True)
         $ insert (Identity $ Just ())
         $ insert (Identity [()])
         $ insert (Identity ())
-        $ insert (Identity "aaa")
+        $ insert (Identity @String "aaa")
         $ insert (Identity $ Just 'a')
         $ insert (Identity 'a')
         $ insert (Identity (11 :: Int)) empty

--- a/test/Test/TypeRep/CacheMap.hs
+++ b/test/Test/TypeRep/CacheMap.hs
@@ -44,7 +44,7 @@ mapOf10 = insert True
         $ insert (Just ())
         $ insert [()]
         $ insert ()
-        $ insert "aaa"
+        $ insert @String "aaa"
         $ insert (Just 'a')
         $ insert 'a'
         $ insert (11 :: Int) empty

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.4
 name:                typerep-map
 version:             0.3.2
 synopsis:            Efficient implementation of a dependent map with types as keys
@@ -20,105 +21,97 @@ homepage:            https://github.com/kowainik/typerep-map
 bug-reports:         https://github.com/kowainik/typerep-map/issues
 license:             MIT
 license-file:        LICENSE
-author:              Kowainik, Vladislav Zavialov
-maintainer:          xrom.xkov@gmail.com
+author:              Veronika Romashkina, Vladislav Zavialov, Dmitrii Kovanikov
+maintainer:          Kowainik <xrom.xkov@gmail.com>
 copyright:           2017-2019 Kowainik
 category:            Data, Data Structures, Types
 build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md
-cabal-version:       2.0
 tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
-                   , GHC == 8.6.3
+                   , GHC == 8.6.5
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/typerep-map.git
 
+common common-options
+  build-depends:       base >= 4.10 && < 4.13
+
+  default-language:    Haskell2010
+  default-extensions:  BangPatterns
+                       OverloadedStrings
+                       RecordWildCards
+                       ScopedTypeVariables
+                       TypeApplications
+
 library
+  import:              common-options
   hs-source-dirs:      src
   exposed-modules:     Data.TMap
                        Data.TypeRepMap
                        Data.TypeRepMap.Internal
-  ghc-options:         -Wall
-  build-depends:       base >= 4.10 && < 5
-                     , containers >= 0.5.10.2 && < 0.7
+
+  build-depends:       containers >= 0.5.10.2 && < 0.7
                      , ghc-prim ^>= 0.5.1.1
                      , primitive ^>= 0.6.4
                      , deepseq ^>= 1.4
-  default-extensions:  OverloadedStrings
-                       RecordWildCards
-                       ScopedTypeVariables
-                       TypeApplications
-  default-language:    Haskell2010
 
 library typerep-extra-impls
+  import:              common-options
   hs-source-dirs:      typerep-extra-impls
   exposed-modules:     Data.TypeRep.CMap
                        Data.TypeRep.OptimalVector
                        Data.TypeRep.Vector
-  ghc-options:         -Wall
-  build-depends:       base >= 4.10 && < 5
-                     , containers >= 0.5.10.2 && < 0.7
+
+  build-depends:       containers >= 0.5.10.2 && < 0.7
                      , vector ^>= 0.12.0.1
                      , deepseq ^>= 1.4
-  default-extensions:  OverloadedStrings
-                       RecordWildCards
-                       ScopedTypeVariables
-                       TypeApplications
-
-  default-language:    Haskell2010
 
 test-suite typerep-map-test
+  import:              common-options
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
+
   main-is:             Test.hs
   other-modules:       Test.TypeRep.CMap
                      , Test.TypeRep.CacheMap
                      , Test.TypeRep.MapProperty
                      , Test.TypeRep.Vector
                      , Test.TypeRep.VectorOpt
-  build-depends:       base >= 4.10 && < 5
-                     , ghc-typelits-knownnat >= 0.4.2 && < 0.7
-                     , hedgehog >= 0.5.3 && < 0.7
+
+  build-tool-depends:  tasty-discover:tasty-discover
+  build-depends:       ghc-typelits-knownnat >= 0.4.2 && < 0.7
+                     , hedgehog ^>= 1.0
                      , typerep-map
                      , typerep-extra-impls
                      , tasty >= 1.0.1.1 && < 1.3
                      , tasty-discover >= 4.1.1 && < 4.3
-                     , tasty-hedgehog >= 0.1.0.2 && < 0.3
+                     , tasty-hedgehog ^>= 1.0.0.0
                      , tasty-hspec ^>= 1.1.5
-                     , QuickCheck >= 2.11.3 && < 2.13
-  build-tool-depends:  tasty-discover:tasty-discover
-  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  default-extensions:  ScopedTypeVariables
-                       TypeApplications
 
-  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
 
 benchmark typerep-map-benchmark
+  import:              common-options
   type:                exitcode-stdio-1.0
-  default-language:    Haskell2010
-  ghc-options:         -Wall -O2 -threaded -rtsopts -with-rtsopts=-N -freduction-depth=0
   hs-source-dirs:      benchmark
+
   main-is:             Main.hs
   other-modules:       CMap
                      , CacheMap
+                     , DMap
                      , Spec
                      , Vector
                      , OptimalVector
-  build-depends:       base >= 4.10 && < 5
-                     , criterion >= 1.4.1.0 && < 1.6
+
+  build-depends:       criterion >= 1.4.1.0 && < 1.6
                      , deepseq ^>= 1.4.3.0
                      , dependent-map >= 0.2.4.0 && < 0.5
                      , dependent-sum ^>= 0.5
                      , ghc-typelits-knownnat >= 0.4.2 && < 0.7
                      , typerep-map
                      , typerep-extra-impls
-  default-extensions:  OverloadedStrings
-                       RecordWildCards
-                       ScopedTypeVariables
-                       TypeApplications
-                       BangPatterns
-  if impl(ghc >= 8.2.2)
-    other-modules:     DMap
+
+  ghc-options:         -O2 -threaded -rtsopts -with-rtsopts=-N -freduction-depth=0


### PR DESCRIPTION
Resolves #73

* QuickCheck dependency was removed (turns out it was redundant)
* Bump up to GHC-8.6.5
* Updated some metadata in cabal and README
* Migrated to common stanza
* Bump up to hedgehog-1.0