### PR TITLE
Improve delete & insert performance

### DIFF
--- a/src/Data/TMap.hs
+++ b/src/Data/TMap.hs
@@ -87,6 +87,7 @@ one x = coerce (F.one @a @Identity $ coerce x)
 {- |
 
 Insert a value into a 'TMap'.
+TMap optimizes for fast reads rather than inserts, as a trade-off inserts are @O(n)@.
 
 prop> size (insert v tm) >= size tm
 prop> member @a (insert (x :: a) tm) == True
@@ -97,6 +98,9 @@ insert x = coerce (F.insert @a @Identity $ coerce x)
 {-# INLINE insert #-}
 
 {- | Delete a value from a 'TMap'.
+
+TMap optimizes for fast reads rather than modifications, as a trade-off deletes are @O(n)@,
+with an @O(log(n))@ optimization for when the element is already missing.
 
 prop> size (delete @a tm) <= size tm
 prop> member @a (delete @a tm) == False

--- a/src/Data/TypeRepMap/Internal.hs
+++ b/src/Data/TypeRepMap/Internal.hs
@@ -213,7 +213,10 @@ False
 True
 -}
 delete :: forall a (f :: KindOf a -> Type) . Typeable a => TypeRepMap f -> TypeRepMap f
-delete = fromTriples . deleteByFst (typeFp @a) . toTriples
+delete m 
+  | not (member @a m) = m
+  | size m == 1 = empty
+  | otherwise = fromSortedTriples . filter ((/= typeFp @a) . fst3) . toSortedTriples $ m
 {-# INLINE delete #-}
 
 {- |
@@ -406,9 +409,6 @@ toSortedTriples tm = trip <$> ordering
              , indexArray (trKeys tm) i)
     ordering :: [ Int ]
     ordering = generateOrderMapping (size tm)
-
-deleteByFst :: Eq a => a -> [(a, b, c)] -> [(a, b, c)]
-deleteByFst x = filter ((/= x) . fst3)
 
 nubByFst :: (Eq a) => [(a, b, c)] -> [(a, b, c)]
 nubByFst = nubBy ((==) `on` fst3)

--- a/src/Data/TypeRepMap/Internal.hs
+++ b/src/Data/TypeRepMap/Internal.hs
@@ -186,13 +186,7 @@ prop> member @a (insert (x :: f a) tm) == True
 
 -}
 insert :: forall a f . Typeable a => f a -> TypeRepMap f -> TypeRepMap f
-insert x = fromTriples . addX . toTriples
-  where
-    tripleX :: (Fingerprint, Any, Any)
-    tripleX@(fpX, _, _) = (calcFp @a, toAny x, unsafeCoerce $ typeRep @a)
-
-    addX :: [(Fingerprint, Any, Any)] -> [(Fingerprint, Any, Any)]
-    addX l = tripleX : deleteByFst fpX l
+insert x = union (one x)
 {-# INLINE insert #-}
 
 -- Extract the kind of a type. We use it to work around lack of syntax for
@@ -213,7 +207,7 @@ False
 True
 -}
 delete :: forall a (f :: KindOf a -> Type) . Typeable a => TypeRepMap f -> TypeRepMap f
-delete m 
+delete m
   | not (member @a m) = m
   | size m == 1 = empty
   | otherwise = fromSortedTriples . filter ((/= typeFp @a) . fst3) . toSortedTriples $ m


### PR DESCRIPTION
* After #93 ,`insert = union (one x)` gives O(n) inserts, still not great; but better than `O(nlogn)`
* `delete`: Using `toSortedTriples`, which is an `O(n)` way to get a sorted list of triples, we can simply filter out the offending element and rebuild in `O(n)` total time

Addresses https://github.com/kowainik/typerep-map/issues/57

This should be rebased on top of #93  once it's merged,

In the meantime; [these are the relevant commits from just this PR](https://github.com/kowainik/typerep-map/pull/94/files/cb082cd3a8968c6894d44a0510b740dd55290dc3..1fc35afde2eda4f6c957af34e06f20b4395a845f)