### PR TITLE
Add intersection/intersectionWith

### DIFF
--- a/src/Data/TMap.hs
+++ b/src/Data/TMap.hs
@@ -135,6 +135,8 @@ union = F.union
 {-# INLINE union #-}
 
 -- | The intersection of two 'TMap's using a combining function.
+--
+-- @O(n)@
 intersectionWith :: (forall x. Typeable x => x -> x -> x) -> TMap -> TMap -> TMap
 intersectionWith f = F.intersectionWith fId
   where
@@ -144,6 +146,8 @@ intersectionWith f = F.intersectionWith fId
 
 -- | The intersection of two 'TMap's.
 -- It keeps all values from the first map whose keys are present in the second.
+--
+-- @O(n)@
 intersection :: TMap -> TMap -> TMap
 intersection = F.intersection
 {-# INLINE intersection #-}

--- a/src/Data/TMap.hs
+++ b/src/Data/TMap.hs
@@ -37,6 +37,8 @@ module Data.TMap
        , delete
        , unionWith
        , union
+       , intersectionWith
+       , intersection
        , map
        , adjust
        , alter
@@ -131,6 +133,20 @@ unionWith f = F.unionWith fId
 union :: TMap -> TMap -> TMap
 union = F.union
 {-# INLINE union #-}
+
+-- | The intersection of two 'TMap's using a combining function.
+intersectionWith :: (forall x. Typeable x => x -> x -> x) -> TMap -> TMap -> TMap
+intersectionWith f = F.intersectionWith fId
+  where
+    fId :: forall y . Typeable y => Identity y -> Identity y -> Identity y
+    fId y1 y2 = f (coerce y1) (coerce y2)
+{-# INLINE intersectionWith #-}
+
+-- | The intersection of two 'TMap's.
+-- It keeps all values from the first map whose keys are present in the second.
+intersection :: TMap -> TMap -> TMap
+intersection = F.intersection
+{-# INLINE intersection #-}
 
 {- | Lookup a value of the given type in a 'TMap'.
 

--- a/src/Data/TMap.hs
+++ b/src/Data/TMap.hs
@@ -136,7 +136,7 @@ union = F.union
 
 -- | The intersection of two 'TMap's using a combining function.
 --
--- @O(n)@
+-- @O(n + m)@
 intersectionWith :: (forall x. Typeable x => x -> x -> x) -> TMap -> TMap -> TMap
 intersectionWith f = F.intersectionWith fId
   where
@@ -147,7 +147,7 @@ intersectionWith f = F.intersectionWith fId
 -- | The intersection of two 'TMap's.
 -- It keeps all values from the first map whose keys are present in the second.
 --
--- @O(n)@
+-- @O(n + m)@
 intersection :: TMap -> TMap -> TMap
 intersection = F.intersection
 {-# INLINE intersection #-}

--- a/src/Data/TypeRepMap.hs
+++ b/src/Data/TypeRepMap.hs
@@ -63,6 +63,8 @@ module Data.TypeRepMap
        , hoistWithKey
        , unionWith
        , union
+       , intersectionWith
+       , intersection
 
          -- * Query
        , lookup

--- a/src/Data/TypeRepMap/Internal.hs
+++ b/src/Data/TypeRepMap/Internal.hs
@@ -350,7 +350,9 @@ union :: TypeRepMap f -> TypeRepMap f -> TypeRepMap f
 union = unionWith const
 {-# INLINE union #-}
 
--- | The intersection of two 'TypeRepMap's using a combining function
+-- | The 'intersection' of two 'TypeRepMap's using a combining function
+--
+-- @O(n)@
 intersectionWith :: forall f. (forall x. Typeable x => f x -> f x -> f x) -> TypeRepMap f -> TypeRepMap f -> TypeRepMap f
 intersectionWith f ma mb =
     fromSortedTriples $ mergeMaps (toSortedTriples ma) (toSortedTriples mb)
@@ -363,22 +365,28 @@ intersectionWith f ma mb =
 
     -- Merges two typrepmaps into a sorted, dedup'd list of triples.
     mergeMaps :: [(Fingerprint, Any, Any)] -> [(Fingerprint, Any, Any)] -> [(Fingerprint, Any, Any)]
+    -- If either list is empty, the intersection must be finished.
     mergeMaps _ [] = []
     mergeMaps [] _ = []
-    -- Merge
-    mergeMaps (a@(af, _, _) : as) (b@(bf, _, _) : bs)
-      -- Fingerprints are equal, union the elements using our function
-      -- If the incoming maps were de-duped, there shouldn't be any other equivalent
-      -- fingerprints
-      | af == bf = combine a b : mergeMaps as bs
-      -- First fingerprint must not be in the second map or we would have seen it by now
-      -- Skip it an move on
-      | af < bf = mergeMaps as (b : bs)
-      | otherwise = mergeMaps (a:as) bs
+    -- Merge the two maps considering one element at a time.
+    mergeMaps (a@(af, _, _) : as) (b@(bf, _, _) : bs) = 
+        case compare af bf of
+            -- Fingerprints are equal, union the elements using our function
+            -- If the incoming maps were de-duped, there shouldn't be any other equivalent
+            -- fingerprints
+            EQ -> combine a b : mergeMaps as bs
+            -- First fingerprint must not be in the second map or we would have seen it by now
+            -- Skip it an move on
+            LT -> mergeMaps as (b : bs)
+            -- Second fingerprint must not be in the first map or we would have seen it by now
+            -- Skip it an move on
+            GT -> mergeMaps (a:as) bs
 {-# INLINE intersectionWith #-}
 
 -- | The intersection of two 'TypeRepMap's. 
 -- It keeps all values from the first map whose keys are present in the second.
+--
+-- @O(n)@
 intersection :: TypeRepMap f -> TypeRepMap f -> TypeRepMap f
 intersection = intersectionWith const
 {-# INLINE intersection #-}

--- a/src/Data/TypeRepMap/Internal.hs
+++ b/src/Data/TypeRepMap/Internal.hs
@@ -352,7 +352,7 @@ union = unionWith const
 
 -- | The 'intersection' of two 'TypeRepMap's using a combining function
 --
--- @O(n)@
+-- @O(n + m)@
 intersectionWith :: forall f. (forall x. Typeable x => f x -> f x -> f x) -> TypeRepMap f -> TypeRepMap f -> TypeRepMap f
 intersectionWith f ma mb =
     fromSortedTriples $ mergeMaps (toSortedTriples ma) (toSortedTriples mb)
@@ -386,7 +386,7 @@ intersectionWith f ma mb =
 -- | The intersection of two 'TypeRepMap's. 
 -- It keeps all values from the first map whose keys are present in the second.
 --
--- @O(n)@
+-- @O(n + m)@
 intersection :: TypeRepMap f -> TypeRepMap f -> TypeRepMap f
 intersection = intersectionWith const
 {-# INLINE intersection #-}

--- a/test/Test/TypeRep/TypeRepMapProperty.hs
+++ b/test/Test/TypeRep/TypeRepMapProperty.hs
@@ -20,8 +20,8 @@ import Test.Hspec (Arg, Expectation, Spec, SpecWith, describe, it)
 import Test.Hspec.Hedgehog (hedgehog)
 
 import Data.TypeRepMap.Internal (TypeRepMap (..), WrapTypeable (..), delete, insert, invariantCheck,
-                                 lookup, member, generateOrderMapping, fromSortedList, alter,
-                                 adjust)
+                                 lookup, member, union, generateOrderMapping, fromSortedList,
+                                 adjust, alter, intersection)
 
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -39,6 +39,7 @@ typeRepMapPropertySpec = describe "TypeRepMap Property tests" $ do
         alterDeleteSpec
         alterAdjustSpec
         alterModifySpec
+        intersectionSpec
     describe "Internal helpers" $ do
         generateOrderMappingInvariantSpec
     describe "Instance Laws" $ do
@@ -117,6 +118,12 @@ alterModifySpec = it "lookup k (alter f) == f (lookup k m)" $ hedgehog $ do
           | even n = Nothing
           | otherwise = Just $ IntProxy p (n * 10)
     lookup @n @IntProxy (alter @n f m) === f (lookup @n @IntProxy m)
+
+intersectionSpec :: Property
+intersectionSpec = it "m `intersection` (m `union` n) == m" $ hedgehog $ do
+    m <- forAll genMap
+    n <- forAll genMap
+    m `intersection` (m `union` n) === m
 
 ----------------------------------------------------------------------------
 -- Internal helpers


### PR DESCRIPTION
Uses some work from #93 ; I.e. this uses the same merge sort strategy, but omits elements that aren't in both maps.

[Here's the only new commit](https://github.com/kowainik/typerep-map/pull/96/commits/1bed838799d69375af7572a710dd955a51ae2eaf)