### PR TITLE
Use DMap instead of Map

### DIFF
--- a/typerep-extra-impls/Data/TypeRep/CMap.hs
+++ b/typerep-extra-impls/Data/TypeRep/CMap.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints #-}
+#endif
 
 {- |
 Copyright:  (c) 2017-2020 Kowainik
@@ -21,29 +27,29 @@ import Prelude hiding (lookup)
 
 import Control.DeepSeq
 import Data.Kind (Type)
-import Data.Proxy (Proxy (..))
-import Data.Typeable (TypeRep, Typeable, typeRep)
-import GHC.Base (Any)
-import Unsafe.Coerce (unsafeCoerce)
+import Type.Reflection (TypeRep, Typeable, typeRep, SomeTypeRep (..), withTypeable)
 
-import qualified Data.Map.Lazy as LMap
+import qualified Data.Dependent.Map as DMap
+import Data.Dependent.Sum (DSum (..))
 
 
 -- | Map-like data structure with types served as the keys.
 newtype TypeRepMap (f :: k -> Type) = TypeRepMap
-    { unMap :: LMap.Map TypeRep Any
+    { unMap :: DMap.DMap TypeRep f
     }
 
-instance NFData (TypeRepMap f) where
-  rnf x = rnf (keys x) `seq` ()
+#if __GLASGOW_HASKELL__ >= 806
+instance forall k (f :: k -> Type). (forall (v :: k). Typeable v => NFData (f v)) => NFData (TypeRepMap f) where
+  rnf = DMap.foldrWithKey (\ kv fv r -> withTypeable kv $ fv `deepseq` r) () . unMap
+#endif
 
 -- | Empty structure.
 empty :: TypeRepMap f
-empty = TypeRepMap mempty
+empty = TypeRepMap DMap.empty
 
 -- | Inserts the value with its type as a key.
 insert :: forall a f . Typeable a => f a -> TypeRepMap f -> TypeRepMap f
-insert val = TypeRepMap . LMap.insert (typeRep (Proxy :: Proxy a)) (unsafeCoerce val) . unMap
+insert val = TypeRepMap . DMap.insert (typeRep @a) val . unMap
 
 -- | Looks up the value at the type.
 -- >>> let x = lookup $ insert (11 :: Int) empty
@@ -52,10 +58,10 @@ insert val = TypeRepMap . LMap.insert (typeRep (Proxy :: Proxy a)) (unsafeCoerce
 -- >>> x :: Maybe ()
 -- Nothing
 lookup :: forall a f . Typeable a => TypeRepMap f -> Maybe (f a)
-lookup = fmap unsafeCoerce . LMap.lookup (typeRep (Proxy :: Proxy a)) . unMap
+lookup = DMap.lookup (typeRep @a) . unMap
 
 size :: TypeRepMap f -> Int
-size = LMap.size . unMap
+size = DMap.size . unMap
 
-keys :: TypeRepMap f -> [TypeRep]
-keys = LMap.keys . unMap
+keys :: TypeRepMap f -> [SomeTypeRep]
+keys (TypeRepMap m) = [SomeTypeRep k | k :=> _ <- DMap.assocs m]

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -83,9 +83,10 @@ library typerep-extra-impls
                        Data.TypeRep.OptimalVector
                        Data.TypeRep.Vector
 
-  build-depends:       containers >= 0.5.10.2 && < 0.7
-                     , vector ^>= 0.12.0.1
+  build-depends:       vector ^>= 0.12.0.1
                      , deepseq ^>= 1.4
+                     , dependent-map >= 0.3
+                     , dependent-sum >= 0.7
 
 test-suite typerep-map-test
   import:              common-options


### PR DESCRIPTION
* `CMap` was defined to use `Data.Map`. Change it to use
  `Data.Dependent.Map` instead, eliminating all the unsafe coercions.
* The `NFData` instance for `CMap` was utterly bogus—it forced only the
  keys and not the values. Use `QuantifiedConstraints`, where available,
  to remedy this.