### PR TITLE
add support for GHC 9.4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.6.2.0"]
+        cabal: ["3.8.1.0"]
         ghc:
           - "8.2.2"
           - "8.4.4"
@@ -26,7 +26,10 @@ jobs:
           - "8.10.7"
           - "9.0.2"
           - "9.2.1"
+          - "9.4.2"
         exclude:
+          - os: macOS-latest
+            ghc: 9.2.1
           - os: macOS-latest
             ghc: 9.0.2
           - os: macOS-latest
@@ -40,6 +43,8 @@ jobs:
           - os: macOS-latest
             ghc: 8.2.2
 
+          - os: windows-latest
+            ghc: 9.2.1
           - os: windows-latest
             ghc: 9.0.2
           - os: windows-latest

--- a/src/Data/TypeRepMap/Internal.hs
+++ b/src/Data/TypeRepMap/Internal.hs
@@ -59,7 +59,13 @@ import GHC.Base (Any, Int (..), Int#, (*#), (+#), (<#))
 import GHC.Exts (IsList (..), inline, sortWith)
 import GHC.Fingerprint (Fingerprint (..))
 #if WORD_SIZE_IN_BITS >= 64
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Prim (eqWord64#, ltWord64#)
+#define eqWord eqWord64
+#define ltWord ltWord64
+#else
 import GHC.Prim (eqWord#, ltWord#)
+#endif
 #else
 import GHC.IntWord64 (eqWord64#, ltWord64#)
 #define eqWord eqWord64

--- a/typerep-map.cabal
+++ b/typerep-map.cabal
@@ -35,13 +35,14 @@ tested-with:         GHC == 8.2.2
                    , GHC == 8.10.7
                    , GHC == 9.0.2
                    , GHC == 9.2.1
+                   , GHC == 9.4.2
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/typerep-map.git
 
 common common-options
-  build-depends:       base >= 4.10 && < 4.17
+  build-depends:       base >= 4.10 && < 4.18
 
   default-language:    Haskell2010
   default-extensions:  BangPatterns
@@ -73,7 +74,7 @@ library
                        Data.TypeRepMap
                        Data.TypeRepMap.Internal
 
-  build-depends:       ghc-prim >= 0.5.1.1 && < 0.9
+  build-depends:       ghc-prim >= 0.5.1.1 && < 0.10
                      , primitive ^>= 0.7.0
                      , deepseq ^>= 1.4
 


### PR DESCRIPTION
There are several redundant import warnings, but I'm not certain of the best way to handle those in a backwards compatible way. :)